### PR TITLE
LIB-61 메일 전송 어댑터 추가 건

### DIFF
--- a/src/main/java/com/liberty52/auth/global/adapter/MailSender.java
+++ b/src/main/java/com/liberty52/auth/global/adapter/MailSender.java
@@ -1,0 +1,38 @@
+package com.liberty52.auth.global.adapter;
+
+import jakarta.mail.MessagingException;
+
+public interface MailSender {
+
+    void prepare(Mail mail) throws MessagingException;
+    void send();
+
+    static Mail buildMail(String to, String title, String content, boolean useHtml) {
+        return new MailSenderImpl.MailImpl(to, title, content, useHtml);
+    }
+
+    interface Mail {
+
+        /**
+         * 수신자 이메일 주소
+         */
+        String getTo();
+
+        /**
+         * 메일 제목
+         */
+        String getTitle();
+
+        /**
+         * 메일 내용
+         */
+        String getContent();
+
+        /**
+         * 메일의 HTML 태그 사용 여부
+         */
+        boolean isUseHtml();
+
+    }
+
+}

--- a/src/main/java/com/liberty52/auth/global/adapter/MailSenderImpl.java
+++ b/src/main/java/com/liberty52/auth/global/adapter/MailSenderImpl.java
@@ -1,0 +1,64 @@
+package com.liberty52.auth.global.adapter;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailAuthenticationException;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MailSenderImpl implements MailSender {
+    private static final String UTF_8 = "UTF-8";
+    private final JavaMailSender sender;
+    @Value("${liberty52.mail.username}")
+    private String OUR_ADDRESS;
+    @Value("${liberty52.mail.nickname}")
+    private String NICKNAME;
+    private String fromAddress;
+    private MimeMessage message;
+    private MimeMessageHelper messageHelper;
+
+    private void initMailSender() throws MessagingException {
+        // Liberty52 <mju.omnm@gmail.com>
+        this.fromAddress = this.NICKNAME + " <" + this.OUR_ADDRESS + ">";
+        this.message = this.sender.createMimeMessage();
+        this.messageHelper = new MimeMessageHelper(this.message, true, UTF_8);
+    }
+
+    @Override
+    public void prepare(Mail mail) throws MessagingException {
+        initMailSender();
+
+        this.messageHelper.setFrom(this.fromAddress);
+        this.messageHelper.setTo(mail.getTo());
+        this.messageHelper.setSubject(mail.getTitle());
+        this.messageHelper.setText(mail.getContent(), mail.isUseHtml());
+    }
+
+    @Override
+    public void send() {
+        try {
+            this.sender.send(this.message);
+        } catch (MailSendException | MailAuthenticationException e) {
+            log.error("Mail Sender Error: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    public static class MailImpl implements Mail {
+        String to;
+        String title;
+        String content;
+        boolean useHtml;
+    }
+}


### PR DESCRIPTION
# 메일 전송 어댑터 추가

LIB-61은 이메일로 비밀번호 찾기 백로그다. 이에 이메일 발송에 대한 처리가 필요하였고,  
타 기능에서도 이메일 발송에 대한 처리가 있음으로 백로그 이전에 메일 전송 어댑터를 먼저 PR 올린다.

## MailSender

```java
public interface MailSender {

    void prepare(Mail mail) throws MessagingException;
    void send();

    static Mail buildMail(String to, String title, String content, boolean useHtml) {
        return new MailSenderImpl.MailImpl(to, title, content, useHtml);
    }

    interface Mail {
        /**
         * 수신자 이메일 주소
         */
        String getTo();

        /**
         * 메일 제목
         */
        String getTitle();

        /**
         * 메일 내용
         */
        String getContent();

        /**
         * 메일의 HTML 태그 사용 여부
         */
        boolean isUseHtml();
    }

}
```

## Usage
> 1. 메일 발송을 요청할 클래스에서 `MailSender`의 빈을 가져온다.
> 2. `MailSender`의 `buildMail(String, String, String, boolean)` 메소드로 Mail을 생성한다.
> 3. `prepare(Mail)` 메소드로 `Mail` 발송을 위해 `MailSender`를 세팅한다.
> 4. `send()` 메소드로 메일을 발송한다.

사용 예시.
```java
        ... 

        MailSender.Mail mail = MailSender.buildMail(email, title, content, true);
        mailSender.prepare(mail);
        new Thread(mailSender::send).start();

        ...
```

## Config
메일을 보내는 아이디나 닉네임, 메일 제목 등 설정에 대한 변경을 소스코드의 영향 밖에서 처리하기 위해 설정파일로 관리한다.

메일을 요청하는 기능은 `liberty52.mail` 하위로 설정 값을 추가하고, 해당 클래스에서 `@Value()`로 호출해오면 된다.

컨피그 설정 파일 - mail-config.yml https://github.com/Liberty52/config-file-repository/blob/main/mail-config.yml


## Think..
prepare()랑 send()랑 원큐에 가는 방향도 고려중