### PR TITLE
fix: 회원 정보수정 로직 변경

### DIFF
--- a/src/main/java/com/liberty52/auth/service/applicationservice/MemberModifyServiceImpl.java
+++ b/src/main/java/com/liberty52/auth/service/applicationservice/MemberModifyServiceImpl.java
@@ -47,7 +47,10 @@ public class MemberModifyServiceImpl implements MemberModifyService{
     }
 
     String profileImageUrl = uploadImage(imageFile);
-    auth.updateUser(dto.getPhoneNumber(),dto.getName(),profileImageUrl);
+    if (profileImageUrl != null){
+      auth.updateUserProfile(profileImageUrl);
+    }
+    auth.updateUser(dto.getPhoneNumber(),dto.getName());
   }
 
   private String uploadImage(MultipartFile multipartFile) {

--- a/src/main/java/com/liberty52/auth/service/entity/Auth.java
+++ b/src/main/java/com/liberty52/auth/service/entity/Auth.java
@@ -52,9 +52,12 @@ public class Auth {
         passwordModifyRequestDate = createdAt.plusMonths(6);
     }
 
-    public void updateUser(String phoneNumber, String name,String profileUrl) {
+    public void updateUser(String phoneNumber, String name) {
         this.phoneNumber = phoneNumber;
         this.name = name;
+    }
+
+    public void updateUserProfile(String profileUrl) {
         this.profileUrl = profileUrl;
     }
 

--- a/src/test/java/com/liberty52/auth/service/applicationservice/ProfileRetrieveServiceImplTest.java
+++ b/src/test/java/com/liberty52/auth/service/applicationservice/ProfileRetrieveServiceImplTest.java
@@ -36,7 +36,8 @@ class ProfileRetrieveServiceImplTest {
         for (int i = 0; i < 3; i++) {
             Auth profile = Auth.createUser("uniqueEmail" + i, "12345678",
                     "KIM", null, "PROFILE");
-            profile.updateUser(null, "KIM"+profile.getId(), "PROFILE");
+            profile.updateUser(null, "KIM"+profile.getId());
+            profile.updateUserProfile("PROFILE");
             ids.add(profile.getId());
             em.persist(profile);
         }


### PR DESCRIPTION
- 이미지 파일이 null 이면 auth의 profileUrl이 바뀌지 않도록 수정