### PR TITLE
로그인 리퀘스트 바디 데이터타입 변경

### DIFF
--- a/src/main/java/com/liberty52/auth/service/applicationservice/impl/LoginServiceImpl.java
+++ b/src/main/java/com/liberty52/auth/service/applicationservice/impl/LoginServiceImpl.java
@@ -31,7 +31,7 @@ public class LoginServiceImpl implements LoginService {
     if (!encoder.matches(dto.getPassword(), auth.getPassword())) {
       throw new AuthUnauthorizedException();
     }
-    String refreshToken = jwtService.createTokensAndAddHeaders(auth, dto.isAutoLogin(), response);
+    String refreshToken = jwtService.createTokensAndAddHeaders(auth, dto.getIsAutoLogin(), response);
     if (refreshToken != null) {
       auth.updateRefreshToken(refreshToken);
     }

--- a/src/main/java/com/liberty52/auth/service/controller/LoginController.java
+++ b/src/main/java/com/liberty52/auth/service/controller/LoginController.java
@@ -7,12 +7,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/liberty52/auth/service/controller/dto/LoginRequestDto.java
+++ b/src/main/java/com/liberty52/auth/service/controller/dto/LoginRequestDto.java
@@ -11,5 +11,5 @@ public class LoginRequestDto {
     @NotBlank
     private String password;
     @NotNull
-    private boolean isAutoLogin;
+    private Boolean isAutoLogin;
 }


### PR DESCRIPTION
이슈 번호 #95

로그인 리퀘스트 바디 중 isAutoLogin이 boolean으로 설정되면 get 함수가 isAutoLogin으로 생성됨.
근데 롬복은 boolean에 버그 같은 게 있어서 autoLogin -> isAutoLogin으로 겟 함수를 만듦.

그래서 롬복 쓸 때 getter에 boolean 데이터 타입에 prefix is 를 붙히면 작동 안함.

그 결과 체크를 했음에도 현재 리프래시 토큰을 안보내고 있음.

Boolean으로 수정한 결과로 refresh 전달

![image](https://github.com/Liberty52/auth/assets/76154390/7bffb39a-08a2-421e-80fc-73c124210a08)

