### PR TITLE
CD 파이프라인 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,37 @@
+name: Deploy dev
+
+on:
+  workflow_run:
+    workflows:
+      - "Build and Push Docker Image for DEV"
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    env:
+      DOCKER_IMAGE: ghcr.io/liberty52/liberty52-auth-server:dev-${{ steps.latest-tag.outputs.tag_name }}
+
+    steps:
+      - name: Get latest Release tag
+        id: latest-tag
+        uses: robinraju/release-downloader@v1.8
+        with:
+          latest: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy AWS EC2 dev
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.REMOTE_IP_DEV }}
+          username: ${{ secrets.REMOTE_SSH_ID_DEV }}
+          key: ${{ secrets.REMOTE_SSH_KEY_DEV }}
+          port: ${{ secrets.REMOTE_SSH_PORT_DEV }}
+          script: |
+            echo ${{ secrets.GTOKEN }} | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            sudo docker pull $DOCKER_IMAGE
+            container_name=$(sudo docker ps | grep liberty52 | awk '{print $NF}')
+            sudo docker stop $container_name
+            sudo docker run -d -p 8080:8080 $DOCKER_IMAGE

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,8 +11,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    env:
-      DOCKER_IMAGE: ghcr.io/liberty52/liberty52-auth-server:dev-${{ steps.latest-tag.outputs.tag_name }}
 
     steps:
       - name: Get latest Release tag
@@ -24,6 +22,9 @@ jobs:
 
       - name: Deploy AWS EC2 dev
         uses: appleboy/ssh-action@master
+        env:
+          DOCKER_IMAGE: ghcr.io/liberty52/liberty52-auth-server:dev-${{ steps.latest-tag.outputs.tag_name }}
+
         with:
           host: ${{ secrets.REMOTE_IP_DEV }}
           username: ${{ secrets.REMOTE_SSH_ID_DEV }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,30 @@
+name: Deploy prod
+
+on:
+  workflow_run:
+    workflows:
+      - "Build and Push Docker Image for PROD"
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    env:
+      DOCKER_IMAGE: ghcr.io/liberty52/liberty52-auth-server:prod-${{ github.sha }}
+
+    steps:
+      - name: Deploy AWS EC2 dev
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.REMOTE_IP_PROD }}
+          username: ${{ secrets.REMOTE_SSH_ID_PROD }}
+          key: ${{ secrets.REMOTE_SSH_KEY_PROD }}
+          port: ${{ secrets.REMOTE_SSH_PORT_PROD }}
+          script: |
+            echo ${{ secrets.GTOKEN }} | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            sudo docker pull $DOCKER_IMAGE
+            container_name=$(sudo docker ps | grep liberty52 | awk '{print $NF}')
+            sudo docker stop $container_name
+            sudo docker run -d -p 8080:8080 $DOCKER_IMAGE

--- a/.github/workflows/docker-ci-dev.yml
+++ b/.github/workflows/docker-ci-dev.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Build and Push Docker Image for DEV
 
 on:
   push:

--- a/.github/workflows/docker-ci-prod.yml
+++ b/.github/workflows/docker-ci-prod.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Build and Push Docker Image for PROD
 
 on:
   push:


### PR DESCRIPTION
## 스프린트 넘버  : 1
## 메이저 마일스톤 :
### 마이너 마일스톤 :
### 백로그 이름 :

Related Issue: https://github.com/Liberty52/auth/issues/101

***
### 작업

CD 파이프라인을 추가하였습니다.

파이프라인은 dev, prod 각각 진행되며, 두 파이프라인 모두 각 `docker-ci-{ profile }.yml` 파일을 의존하게 됩니다.

`appleboy/ssh-action` 플러그인을 통해 AWS EC2에 SSH 접속 후 `docker pull -> docker stop -> docker run` 명령을 수행합니다.

이때, 현재까지(23.09.23)의 CI 워크플로우를 참고하여, dev는 릴리즈 Asset latest의 태그이름을, prod는 github.sha를, 기준으로 도커 이미지 태그로 하여 레지스트리로부터 당겨옵니다. 

또한 각 프로파일에 대응되는 CI 워크플로우를 의존받기 위해 기존 CI 워크플로우의 name을 수정하였습니다.

**dev**
AS-IS: Build and Push Docker Image
TO-BE: Build and Push Docker Image for DEV

**prod**
AS-IS: Build and Push Docker Image
TO-BE: Build and Push Docker Image for PROD

***
### 테스트 결과

CI 워크플로우에 의존하기 전에 `chore/101-cd-pipeline` 브랜치의 푸시 이벤트를 트리거로 하여 테스트해 본 결과, 정상적으로 pull, run이 되었습니다.
<img width="1165" alt="image" src="https://github.com/Liberty52/auth/assets/42243302/8e09325e-ed99-452b-9675-d08c3b2cbb6d">

**다만 아직 CI 워크플로우 의존 후의 테스트는 해보지 못하였습니다.**

***
### 이슈
TO: @ImKunYoung 
1. 현재 릴리즈 태그 이름이 당일 date 기준으로 되어있는데, 버전화하는 건 어떨까요? e.g., 1.0.0, 1.0.1, ..., etc.
AS-IS: Release v-2023.09.22-112309
TO-BE: 1.x.x
2. 제가 작성한 CI 워크플로우 의존 이외에 다른 방법이 있다면 적극 피드백 부탁드립니다.