### PR TITLE
공지사항 댓글 생성

### DIFF
--- a/src/main/java/com/liberty52/auth/service/applicationservice/NoticeCommentCreateService.java
+++ b/src/main/java/com/liberty52/auth/service/applicationservice/NoticeCommentCreateService.java
@@ -1,0 +1,8 @@
+package com.liberty52.auth.service.applicationservice;
+
+import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
+import com.liberty52.auth.service.entity.NoticeComment;
+
+public interface NoticeCommentCreateService {
+    NoticeComment createNoticeComment(String writerId, String noticeId, NoticeCommentRequestDto requestDto);
+}

--- a/src/main/java/com/liberty52/auth/service/applicationservice/impl/NoticeCommentCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/auth/service/applicationservice/impl/NoticeCommentCreateServiceImpl.java
@@ -1,0 +1,39 @@
+package com.liberty52.auth.service.applicationservice.impl;
+
+import com.liberty52.auth.global.exception.external.notfound.NoticeNotFoundById;
+import com.liberty52.auth.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.auth.global.exception.external.unauthorized.AuthNotFoundException;
+import com.liberty52.auth.service.applicationservice.NoticeCommentCreateService;
+import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
+import com.liberty52.auth.service.entity.Auth;
+import com.liberty52.auth.service.entity.Notice;
+import com.liberty52.auth.service.entity.NoticeComment;
+import com.liberty52.auth.service.repository.AuthRepository;
+import com.liberty52.auth.service.repository.NoticeCommentRepository;
+import com.liberty52.auth.service.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NoticeCommentCreateServiceImpl implements NoticeCommentCreateService {
+    private final AuthRepository authRepository;
+    private final NoticeRepository noticeRepository;
+    private final NoticeCommentRepository noticeCommentRepository;
+
+    @Override
+    public NoticeComment createNoticeComment(String writerId, String noticeId, NoticeCommentRequestDto requestDto) {
+        Auth auth = authRepository.findById(writerId).orElseThrow(AuthNotFoundException::new);
+        Notice notice = noticeRepository.findById(noticeId).orElseThrow(()-> new NoticeNotFoundById(noticeId));
+        NoticeComment noticeComment = NoticeComment.builder()
+                .notice(notice)
+                .writer(auth)
+                .content(requestDto.getContent())
+                .build();
+
+        return noticeCommentRepository.save(noticeComment);
+    }
+
+}

--- a/src/main/java/com/liberty52/auth/service/controller/NoticeCommentController.java
+++ b/src/main/java/com/liberty52/auth/service/controller/NoticeCommentController.java
@@ -1,0 +1,30 @@
+package com.liberty52.auth.service.controller;
+
+import com.liberty52.auth.service.applicationservice.NoticeCommentCreateService;
+import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
+import com.liberty52.auth.service.controller.dto.NoticeCommentResponseDto;
+import com.liberty52.auth.service.entity.NoticeComment;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+public class NoticeCommentController {
+    private final NoticeCommentCreateService noticeCommentCreateService;
+    @Operation(summary = "공지사항 댓글 생성", description = "공지사항에 대한 댓글을 생성합니다.")
+    @PostMapping("/notices/{noticeId}/comments")
+    public ResponseEntity<NoticeCommentResponseDto> createNoticeComment(@RequestHeader(HttpHeaders.AUTHORIZATION) String userId,
+                                                                        @PathVariable String noticeId,
+                                                                        @RequestBody @Valid NoticeCommentRequestDto requestDto){
+        NoticeComment resultEntity = noticeCommentCreateService.createNoticeComment(userId, noticeId, requestDto);
+        NoticeCommentResponseDto responseDto = new NoticeCommentResponseDto(resultEntity);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+
+}

--- a/src/main/java/com/liberty52/auth/service/controller/dto/NoticeCommentRequestDto.java
+++ b/src/main/java/com/liberty52/auth/service/controller/dto/NoticeCommentRequestDto.java
@@ -1,0 +1,10 @@
+package com.liberty52.auth.service.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class NoticeCommentRequestDto {
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/com/liberty52/auth/service/controller/dto/NoticeCommentResponseDto.java
+++ b/src/main/java/com/liberty52/auth/service/controller/dto/NoticeCommentResponseDto.java
@@ -1,0 +1,31 @@
+package com.liberty52.auth.service.controller.dto;
+
+import com.liberty52.auth.service.entity.NoticeComment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class NoticeCommentResponseDto {
+    private String commentId;
+    private String noticeId;
+    private String writerId;
+    private String writerName;
+    private String writerEmail;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public NoticeCommentResponseDto(NoticeComment resultEntity) {
+        this.commentId = resultEntity.getId();
+        this.noticeId = resultEntity.getNotice().getId();
+        this.writerId = resultEntity.getWriter().getId();
+        this.writerName = resultEntity.getWriter().getName();
+        this.writerEmail = resultEntity.getWriter().getEmail();
+        this.content = resultEntity.getContent();
+        this.createdAt = resultEntity.getCreatedAt();
+        this.updatedAt = resultEntity.getUpdatedAt();
+    }
+}

--- a/src/main/java/com/liberty52/auth/service/entity/Notice.java
+++ b/src/main/java/com/liberty52/auth/service/entity/Notice.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity

--- a/src/main/java/com/liberty52/auth/service/entity/Notice.java
+++ b/src/main/java/com/liberty52/auth/service/entity/Notice.java
@@ -6,8 +6,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @Entity

--- a/src/main/java/com/liberty52/auth/service/entity/NoticeComment.java
+++ b/src/main/java/com/liberty52/auth/service/entity/NoticeComment.java
@@ -1,0 +1,42 @@
+package com.liberty52.auth.service.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "noticeComment")
+@Getter
+@Setter
+@NoArgsConstructor
+public class NoticeComment {
+    @Id
+    private String id = UUID.randomUUID().toString();
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Auth writer;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Notice notice;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(nullable = true, insertable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private NoticeComment(Notice notice, Auth writer, String content) {
+        this.notice=notice;
+        this.writer=writer;
+        this.content=content;
+    }
+}

--- a/src/main/java/com/liberty52/auth/service/repository/NoticeCommentRepository.java
+++ b/src/main/java/com/liberty52/auth/service/repository/NoticeCommentRepository.java
@@ -1,0 +1,8 @@
+package com.liberty52.auth.service.repository;
+
+import com.liberty52.auth.service.entity.NoticeComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeCommentRepository extends JpaRepository<NoticeComment, String> {
+
+}

--- a/src/test/java/com/liberty52/auth/service/applicationservice/NoticeCommentCreateServiceMockTest.java
+++ b/src/test/java/com/liberty52/auth/service/applicationservice/NoticeCommentCreateServiceMockTest.java
@@ -1,0 +1,84 @@
+package com.liberty52.auth.service.applicationservice;
+
+import com.liberty52.auth.global.exception.external.notfound.NoticeNotFoundById;
+import com.liberty52.auth.service.applicationservice.impl.NoticeCommentCreateServiceImpl;
+import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
+import com.liberty52.auth.service.entity.Auth;
+import com.liberty52.auth.service.entity.Notice;
+import com.liberty52.auth.service.entity.NoticeComment;
+import com.liberty52.auth.service.repository.AuthRepository;
+import com.liberty52.auth.service.repository.NoticeCommentRepository;
+import com.liberty52.auth.service.repository.NoticeRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class NoticeCommentCreateServiceMockTest {
+    @InjectMocks
+    private NoticeCommentCreateServiceImpl noticeCommentCreateService;
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @Mock
+    private NoticeCommentRepository noticeCommentRepository;
+
+    @Mock
+    private AuthRepository authRepository;
+
+    private final String testNoticeId = "NOTICE-001";
+
+    private final String testWriterId = "TESTER-001";
+
+    @Test
+    void 공지사항댓글생성_성공() {
+        //Given
+        Notice mockNotice = mock(Notice.class);
+        Auth mockWriter = mock(Auth.class);
+        NoticeCommentRequestDto mockRequestDto = mock(NoticeCommentRequestDto.class);
+        String testContent = "testContent";
+        NoticeComment mockNoticeComment = NoticeComment.builder()
+                .notice(mockNotice)
+                .writer(mockWriter)
+                .content(testContent)
+                .build();
+        when(authRepository.findById(anyString())).thenReturn(Optional.of(mockWriter));
+        when(noticeRepository.findById(anyString())).thenReturn(Optional.of(mockNotice));
+        when(noticeCommentRepository.save(any(NoticeComment.class))).thenReturn(mockNoticeComment);
+
+        //When
+        NoticeComment savedNoticeComment = noticeCommentCreateService.createNoticeComment(testWriterId, testNoticeId, mockRequestDto);
+
+        //Then
+        assertEquals(mockNotice, savedNoticeComment.getNotice());
+        assertEquals(mockWriter, savedNoticeComment.getWriter());
+        assertEquals(testContent, savedNoticeComment.getContent());
+    }
+
+    @Test
+    void 공지사항댓글생성_실패_없는공지사항() {
+        //Given
+        Auth mockWriter = mock(Auth.class);
+        NoticeCommentRequestDto mockRequestDto = mock(NoticeCommentRequestDto.class);
+        when(authRepository.findById(anyString())).thenReturn(Optional.of(mockWriter));
+
+        //When&Then
+        Assertions.assertThrows(NoticeNotFoundById.class, () -> noticeCommentCreateService.createNoticeComment(testWriterId,"wrong_noticeId",mockRequestDto));
+    }
+
+
+
+
+}

--- a/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
+++ b/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
@@ -1,0 +1,82 @@
+package com.liberty52.auth.service.controller;
+
+
+import com.liberty52.auth.service.applicationservice.NoticeCommentCreateService;
+import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
+import com.liberty52.auth.service.entity.Auth;
+import com.liberty52.auth.service.entity.Notice;
+import com.liberty52.auth.service.entity.NoticeComment;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(NoticeCommentController.class)
+public class NoticeCommentControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private NoticeCommentCreateService noticeCommentCreateService;
+    private final String testNoticeId = "NOTICE-001";
+    private final String testWriterID = "TESTER-001";
+
+    @Test
+    @WithMockUser
+    void 공지사항댓글생성_성공() throws Exception {
+        //Given
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put("content","Test Comment Content");
+        String jsonData = objectMapper.writeValueAsString(requestData);
+
+        NoticeComment noticeCommentMock = new NoticeComment();
+        noticeCommentMock.setNotice(Notice.create("testTitle","testContent",true));
+        noticeCommentMock.setWriter(new Auth());
+        when(noticeCommentCreateService.createNoticeComment(anyString(), anyString(), any(NoticeCommentRequestDto.class)))
+                .thenReturn(noticeCommentMock);
+
+        //When
+        mockMvc.perform(post("/notices/" + testNoticeId + "/comments")
+                        .header(HttpHeaders.AUTHORIZATION, testWriterID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonData)
+                        .with(csrf()))
+                //Then
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    void 공지사항댓글생성_실패_내용없음() throws Exception {
+        //given
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put("content"," ");
+        String jsonData = objectMapper.writeValueAsString(requestData);
+
+        //when
+        mockMvc.perform(post("/notices/" + testNoticeId + "/comments")
+                        .header(HttpHeaders.AUTHORIZATION, testWriterID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonData)
+                        .with(csrf()))
+                //then
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 스프린트 넘버  : 7
### 백로그 이름 : 공지에서 댓글기능 CREATE


***
### 작업
1. ERD 수정
<img width="618" alt="image" src="https://github.com/Liberty52/auth/assets/96376539/08108bd8-a754-4c3d-8322-68f943038a63">

2. NoticeComment 엔티티 추가 및 Auth, Notice와의 연관관계 설정
3. DTO, Controller, Service, Repository 구현
4. 테스트코드 작성

**API**
```
POST /auth/notices/{noticeId}/comments

<Request>
Header: {
 "Authorization" : ${access_token}
}
Body: {
 "content" : String //댓글 내용(Not Blank)
}

<Response>
Status : 200(성공),400(잘못된 데이터로 요청),401(존재하지 않는 유저),403(권한 없음)
Body : {
  "commentId": "72735f0a-4a15-4a1d-ab03-e8f200bbe476", //댓글id
  "noticeId": "NOTICE-001", //해당 댓글이 속한 공지사항id
  "writerId": "TESTER-001", //해당 댓글 작성자id
  "writerName": "김테스터", //해당 댓글 작성자 이름
  "writerEmail": "test@gmail.com", //해당 댓글 작성자 이메일
  "content": "댓글이에요", //댓글 내용
  "createdAt": "2023-11-02T22:45:18.586432", //생성시각
  "updatedAt": null //수정시각
 }
}  
```

***
### 테스트 결과
<img width="287" alt="스크린샷 2023-11-03 오전 1 56 07" src="https://github.com/Liberty52/auth/assets/96376539/7ec26b55-97ad-4fa3-bd79-d9b7c3dd04c5">

<img width="282" alt="스크린샷 2023-11-03 오전 1 56 19" src="https://github.com/Liberty52/auth/assets/96376539/a9e3a994-5c88-4c40-a205-10440b04af1b">


***
### 이슈
Notice <-> NoticeComment 양방향 관계 설정해서 공지사항 조회할때 댓글들까지 모두 나오게 할까 고민했는데, 댓글과 공지사항 모두 페이지네이션이 적용되어서 코드가 너무 두꺼워지고 딱히 필요성을 느끼지 못해 별도의 API로 CRUD 하는 방향으로 결정했어요