### PR TITLE
공지사항 댓글 수정

### DIFF
--- a/src/main/java/com/liberty52/auth/global/exception/external/notfound/NoticeCommentNotFoundById.java
+++ b/src/main/java/com/liberty52/auth/global/exception/external/notfound/NoticeCommentNotFoundById.java
@@ -1,0 +1,7 @@
+package com.liberty52.auth.global.exception.external.notfound;
+
+public class NoticeCommentNotFoundById extends ResourceNotFoundException{
+    public NoticeCommentNotFoundById(String commentId) {
+        super("NoticeComment", "id", commentId);
+    }
+}

--- a/src/main/java/com/liberty52/auth/service/applicationservice/NoticeCommentUpdateService.java
+++ b/src/main/java/com/liberty52/auth/service/applicationservice/NoticeCommentUpdateService.java
@@ -1,0 +1,8 @@
+package com.liberty52.auth.service.applicationservice;
+
+import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
+import com.liberty52.auth.service.entity.NoticeComment;
+
+public interface NoticeCommentUpdateService {
+    NoticeComment updateNoticeComment(String userId, String noticeId, String commentId, NoticeCommentRequestDto requestDto);
+}

--- a/src/main/java/com/liberty52/auth/service/applicationservice/impl/NoticeCommentRetrieveServiceImpl.java
+++ b/src/main/java/com/liberty52/auth/service/applicationservice/impl/NoticeCommentRetrieveServiceImpl.java
@@ -19,6 +19,6 @@ public class NoticeCommentRetrieveServiceImpl implements NoticeCommentRetrieveSe
     @Override
     public Page<NoticeComment> retrieveNoticeComment(String noticeId, Pageable pageable) {
         Notice notice = noticeRepository.findById(noticeId).orElseThrow(()-> new NoticeNotFoundById(noticeId));
-        return noticeCommentRepository.findAllByNoticeId(noticeId,pageable);
+        return noticeCommentRepository.findAllByNoticeId(noticeId, pageable);
     }
 }

--- a/src/main/java/com/liberty52/auth/service/applicationservice/impl/NoticeCommentUpdateServiceImpl.java
+++ b/src/main/java/com/liberty52/auth/service/applicationservice/impl/NoticeCommentUpdateServiceImpl.java
@@ -1,0 +1,37 @@
+package com.liberty52.auth.service.applicationservice.impl;
+
+import com.liberty52.auth.global.exception.external.notfound.NoticeCommentNotFoundById;
+import com.liberty52.auth.global.exception.external.notfound.NoticeNotFoundById;
+import com.liberty52.auth.global.exception.external.notfound.ResourceNotFoundException;
+import com.liberty52.auth.global.exception.external.unauthorized.AuthNotFoundException;
+import com.liberty52.auth.service.applicationservice.NoticeCommentUpdateService;
+import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
+import com.liberty52.auth.service.entity.Auth;
+import com.liberty52.auth.service.entity.Notice;
+import com.liberty52.auth.service.entity.NoticeComment;
+import com.liberty52.auth.service.repository.AuthRepository;
+import com.liberty52.auth.service.repository.NoticeCommentRepository;
+import com.liberty52.auth.service.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NoticeCommentUpdateServiceImpl implements NoticeCommentUpdateService {
+    private final AuthRepository authRepository;
+    private final NoticeRepository noticeRepository;
+    private final NoticeCommentRepository noticeCommentRepository;
+    @Override
+    public NoticeComment updateNoticeComment(String userId, String noticeId, String commentId, NoticeCommentRequestDto requestDto) {
+        Auth auth = authRepository.findById(userId).orElseThrow(AuthNotFoundException::new);
+        Notice notice = noticeRepository.findById(noticeId).orElseThrow(()-> new NoticeNotFoundById(noticeId));
+        NoticeComment noticeComment = noticeCommentRepository.findById(commentId).orElseThrow(()-> new NoticeCommentNotFoundById(commentId));
+        noticeComment.setContent(requestDto.getContent());
+        noticeComment.setUpdatedAt(LocalDateTime.now());
+        return noticeCommentRepository.save(noticeComment);
+    }
+}

--- a/src/main/java/com/liberty52/auth/service/applicationservice/impl/NoticeCommentUpdateServiceImpl.java
+++ b/src/main/java/com/liberty52/auth/service/applicationservice/impl/NoticeCommentUpdateServiceImpl.java
@@ -30,8 +30,7 @@ public class NoticeCommentUpdateServiceImpl implements NoticeCommentUpdateServic
         Auth auth = authRepository.findById(userId).orElseThrow(AuthNotFoundException::new);
         Notice notice = noticeRepository.findById(noticeId).orElseThrow(()-> new NoticeNotFoundById(noticeId));
         NoticeComment noticeComment = noticeCommentRepository.findById(commentId).orElseThrow(()-> new NoticeCommentNotFoundById(commentId));
-        noticeComment.setContent(requestDto.getContent());
-        noticeComment.setUpdatedAt(LocalDateTime.now());
+        noticeComment.modifyContent(requestDto.getContent());
         return noticeCommentRepository.save(noticeComment);
     }
 }

--- a/src/main/java/com/liberty52/auth/service/controller/NoticeCommentController.java
+++ b/src/main/java/com/liberty52/auth/service/controller/NoticeCommentController.java
@@ -2,6 +2,7 @@ package com.liberty52.auth.service.controller;
 
 import com.liberty52.auth.service.applicationservice.NoticeCommentCreateService;
 import com.liberty52.auth.service.applicationservice.NoticeCommentRetrieveService;
+import com.liberty52.auth.service.applicationservice.NoticeCommentUpdateService;
 import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
 import com.liberty52.auth.service.controller.dto.NoticeCommentResponseDto;
 import com.liberty52.auth.service.entity.NoticeComment;
@@ -20,23 +21,39 @@ import org.springframework.web.bind.annotation.*;
 public class NoticeCommentController {
     private final NoticeCommentCreateService noticeCommentCreateService;
     private final NoticeCommentRetrieveService noticeCommentRetrieveService;
+    private final NoticeCommentUpdateService noticeCommentUpdateService;
+
     @Operation(summary = "공지사항 댓글 생성", description = "공지사항에 대한 댓글을 생성합니다.")
     @PostMapping("/notices/{noticeId}/comments")
     public ResponseEntity<NoticeCommentResponseDto> createNoticeComment(@RequestHeader(HttpHeaders.AUTHORIZATION) String userId,
                                                                         @PathVariable String noticeId,
                                                                         @RequestBody @Valid NoticeCommentRequestDto requestDto){
         NoticeComment resultEntity = noticeCommentCreateService.createNoticeComment(userId, noticeId, requestDto);
-        NoticeCommentResponseDto responseDto = new NoticeCommentResponseDto(resultEntity);
+        NoticeCommentResponseDto responseDto = new NoticeCommentResponseDto(resultEntity, userId);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
     @Operation(summary = "공지사항 댓글 조회", description = "공지사항에 대한 댓글을 조회합니다.")
     @GetMapping("/notices/{noticeId}/comments")
-    public ResponseEntity<Page<NoticeCommentResponseDto>> retrieveNoticeComment(@PathVariable String noticeId, Pageable pageable){
+    public ResponseEntity<Page<NoticeCommentResponseDto>> retrieveNoticeComment(@RequestHeader(name = "Authorization", required = false) String userId,
+                                                                                @PathVariable String noticeId,
+                                                                                Pageable pageable){
         Page<NoticeComment> resultEntityPage = noticeCommentRetrieveService.retrieveNoticeComment(noticeId, pageable);
-        Page<NoticeCommentResponseDto> responseDtoPage = NoticeCommentResponseDto.convertEntityPageToDtoPage(resultEntityPage);
+        Page<NoticeCommentResponseDto> responseDtoPage = NoticeCommentResponseDto.convertEntityPageToDtoPage(resultEntityPage, userId);
         return ResponseEntity.status(HttpStatus.OK).body(responseDtoPage);
     }
+
+    @Operation(summary = "공지사항 댓글 수장", description = "공지사항에 대한 댓글을 수정합니다.")
+    @PatchMapping("/notices/{noticeId}/comments/{commentId}")
+    public ResponseEntity<NoticeCommentResponseDto> updateNoticeComment(@RequestHeader(HttpHeaders.AUTHORIZATION) String userId,
+                                                                        @PathVariable String noticeId,
+                                                                        @PathVariable String commentId,
+                                                                        @RequestBody @Valid NoticeCommentRequestDto requestDto){
+        NoticeComment resultEntity = noticeCommentUpdateService.updateNoticeComment(userId, noticeId, commentId, requestDto);
+        NoticeCommentResponseDto responseDto = new NoticeCommentResponseDto(resultEntity, userId);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
 
 
 }

--- a/src/main/java/com/liberty52/auth/service/controller/dto/NoticeCommentResponseDto.java
+++ b/src/main/java/com/liberty52/auth/service/controller/dto/NoticeCommentResponseDto.java
@@ -22,6 +22,7 @@ public class NoticeCommentResponseDto {
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private boolean isMine = false;
 
     public NoticeCommentResponseDto(NoticeComment resultEntity) {
         this.commentId = resultEntity.getId();
@@ -33,10 +34,24 @@ public class NoticeCommentResponseDto {
         this.createdAt = resultEntity.getCreatedAt();
         this.updatedAt = resultEntity.getUpdatedAt();
     }
-    public static Page<NoticeCommentResponseDto> convertEntityPageToDtoPage(Page<NoticeComment> entityPage) {
+
+    public NoticeCommentResponseDto(NoticeComment resultEntity, String userId) {
+        this.commentId = resultEntity.getId();
+        this.noticeId = resultEntity.getNotice().getId();
+        this.writerId = resultEntity.getWriter().getId();
+        this.writerName = resultEntity.getWriter().getName();
+        this.writerEmail = resultEntity.getWriter().getEmail();
+        this.content = resultEntity.getContent();
+        this.createdAt = resultEntity.getCreatedAt();
+        this.updatedAt = resultEntity.getUpdatedAt();
+        if(userId!=null&&userId.equals(resultEntity.getWriter().getId()))
+            this.isMine = true;
+    }
+
+    public static Page<NoticeCommentResponseDto> convertEntityPageToDtoPage(Page<NoticeComment> entityPage, String userId) {
         List<NoticeCommentResponseDto> dtoList = entityPage
                 .stream()
-                .map(NoticeCommentResponseDto::new)
+                .map(resultEntity -> new NoticeCommentResponseDto(resultEntity, userId))
                 .collect(Collectors.toList());
         return new PageImpl<>(dtoList, entityPage.getPageable(), entityPage.getTotalElements());
     }

--- a/src/main/java/com/liberty52/auth/service/entity/NoticeComment.java
+++ b/src/main/java/com/liberty52/auth/service/entity/NoticeComment.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -12,7 +11,6 @@ import java.util.UUID;
 @Entity
 @Table(name = "noticeComment")
 @Getter
-@Setter
 @NoArgsConstructor
 public class NoticeComment {
     @Id
@@ -38,5 +36,10 @@ public class NoticeComment {
         this.notice=notice;
         this.writer=writer;
         this.content=content;
+    }
+
+    public void modifyContent(String content){
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/liberty52/auth/service/repository/NoticeCommentRepository.java
+++ b/src/main/java/com/liberty52/auth/service/repository/NoticeCommentRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-
 public interface NoticeCommentRepository extends JpaRepository<NoticeComment, String> {
     Page<NoticeComment> findAllByNoticeId(String noticeId, Pageable pageable);
 }

--- a/src/main/java/com/liberty52/auth/service/repository/NoticeCommentRepository.java
+++ b/src/main/java/com/liberty52/auth/service/repository/NoticeCommentRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+
 public interface NoticeCommentRepository extends JpaRepository<NoticeComment, String> {
     Page<NoticeComment> findAllByNoticeId(String noticeId, Pageable pageable);
 }

--- a/src/test/java/com/liberty52/auth/service/applicationservice/NoticeCommentUpdateServiceMockTest.java
+++ b/src/test/java/com/liberty52/auth/service/applicationservice/NoticeCommentUpdateServiceMockTest.java
@@ -1,0 +1,78 @@
+package com.liberty52.auth.service.applicationservice;
+
+import com.liberty52.auth.global.exception.external.notfound.NoticeCommentNotFoundById;
+import com.liberty52.auth.service.applicationservice.impl.NoticeCommentUpdateServiceImpl;
+import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
+import com.liberty52.auth.service.entity.Auth;
+import com.liberty52.auth.service.entity.Notice;
+import com.liberty52.auth.service.entity.NoticeComment;
+import com.liberty52.auth.service.repository.AuthRepository;
+import com.liberty52.auth.service.repository.NoticeCommentRepository;
+import com.liberty52.auth.service.repository.NoticeRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class NoticeCommentUpdateServiceMockTest {
+    @InjectMocks
+    private NoticeCommentUpdateServiceImpl noticeCommentUpdateService;
+    @Mock
+    private AuthRepository authRepository;
+    @Mock
+    private NoticeRepository noticeRepository;
+    @Mock
+    private NoticeCommentRepository noticeCommentRepository;
+    private final String testNoticeId = "NOTICE-001";
+    private final String testWriterId = "TESTER-001";
+    private final String testCommentId = "COMMENT-001";
+
+    @Test
+    void 공지사항댓글수정_성공() {
+        //Given
+        Notice mockNotice = mock(Notice.class);
+        Auth mockWriter = mock(Auth.class);
+        NoticeCommentRequestDto mockRequestDto = mock(NoticeCommentRequestDto.class);
+        NoticeComment mockPreviousNoticeComment = NoticeComment.builder()
+                .content("prevContent")
+                .build();
+        NoticeComment mockNewNoticeComment = NoticeComment.builder()
+                .content("newContent")
+                .build();
+        when(authRepository.findById(anyString())).thenReturn(Optional.of(mockWriter));
+        when(noticeRepository.findById(anyString())).thenReturn(Optional.of(mockNotice));
+        when(noticeCommentRepository.findById(anyString())).thenReturn(Optional.of(mockPreviousNoticeComment));
+        when(noticeCommentRepository.save(any(NoticeComment.class))).thenReturn(mockNewNoticeComment);
+
+        //When
+        NoticeComment updatedNoticeComment = noticeCommentUpdateService.updateNoticeComment(testWriterId, testNoticeId, testCommentId, mockRequestDto);
+
+        //Then
+        assertEquals(mockNewNoticeComment.getContent(),"newContent");
+    }
+
+    @Test
+    void 공지사항댓글수정_실패_없는댓글() {
+        //Given
+        Auth mockWriter = mock(Auth.class);
+        NoticeCommentRequestDto mockRequestDto = mock(NoticeCommentRequestDto.class);
+        Notice mockNotice = mock(Notice.class);
+        when(authRepository.findById(anyString())).thenReturn(Optional.of(mockWriter));
+        when(noticeRepository.findById(anyString())).thenReturn(Optional.of(mockNotice));
+
+        //When&Then
+        Assertions.assertThrows(NoticeCommentNotFoundById.class, () -> noticeCommentUpdateService.updateNoticeComment(testWriterId, testNoticeId, "wrong_noticeId", mockRequestDto));
+    }
+
+}

--- a/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
+++ b/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
@@ -3,6 +3,7 @@ package com.liberty52.auth.service.controller;
 
 import com.liberty52.auth.service.applicationservice.NoticeCommentCreateService;
 import com.liberty52.auth.service.applicationservice.NoticeCommentRetrieveService;
+import com.liberty52.auth.service.applicationservice.NoticeCommentUpdateService;
 import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
 import com.liberty52.auth.service.entity.Auth;
 import com.liberty52.auth.service.entity.Notice;
@@ -38,6 +39,8 @@ public class NoticeCommentControllerTest {
     private NoticeCommentCreateService noticeCommentCreateService;
     @MockBean
     private NoticeCommentRetrieveService noticeCommentRetrieveService;
+    @MockBean
+    private NoticeCommentUpdateService noticeCommentUpdateService;
     private final String testNoticeId = "NOTICE-001";
     private final String testWriterID = "TESTER-001";
 

--- a/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
+++ b/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -53,11 +54,13 @@ public class NoticeCommentControllerTest {
         requestData.put("content","Test Comment Content");
         String jsonData = objectMapper.writeValueAsString(requestData);
 
-        NoticeComment noticeCommentMock = new NoticeComment();
-        noticeCommentMock.setNotice(Notice.create("testTitle","testContent",true));
-        noticeCommentMock.setWriter(new Auth());
+        NoticeComment noticeCommentMock = mock(NoticeComment.class);
+        Notice noticeMock = mock(Notice.class);
+        Auth writerMock = mock(Auth.class);
         when(noticeCommentCreateService.createNoticeComment(anyString(), anyString(), any(NoticeCommentRequestDto.class)))
                 .thenReturn(noticeCommentMock);
+        when(noticeCommentMock.getNotice()).thenReturn(noticeMock);
+        when(noticeCommentMock.getWriter()).thenReturn(writerMock);
 
         //When
         mockMvc.perform(post("/notices/" + testNoticeId + "/comments")

--- a/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
+++ b/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
@@ -41,7 +41,6 @@ public class NoticeCommentControllerTest {
     private NoticeCommentRetrieveService noticeCommentRetrieveService;
     @MockBean
     private NoticeCommentUpdateService noticeCommentUpdateService;
-
     private final String testNoticeId = "NOTICE-001";
     private final String testWriterID = "TESTER-001";
 

--- a/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
+++ b/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
@@ -41,6 +41,7 @@ public class NoticeCommentControllerTest {
     private NoticeCommentRetrieveService noticeCommentRetrieveService;
     @MockBean
     private NoticeCommentUpdateService noticeCommentUpdateService;
+
     private final String testNoticeId = "NOTICE-001";
     private final String testWriterID = "TESTER-001";
 


### PR DESCRIPTION
## 스프린트 넘버  : 7
### 백로그 이름 : 공지에서 댓글기능 UPDATE


***
### 작업
공지사항댓글 응답 dto에서 boolean 형의 'isMine' 추가하여 생성/조회/추가 시 내 댓글인지 체크하도록 수정 (Only Dto, Entity x)
관련 Controller, Service, Repository, DTO 작업

**API**
```
PATCH /notices/{noticeId}/comments/{commentId}

<Request>
Header: {
 "Authorization" : ${access_token}
}
Body: {
 "content" : String //수정할 댓글 내용(Not Blank)
}

<Response>
Status : 200(성공),400(잘못된 데이터로 요청),401(존재하지 않는 유저),403(권한 없음),404(존재하지 않는 공지사항 or 댓글)
Body : {
  "commentId": "72735f0a-4a15-4a1d-ab03-e8f200bbe476", //댓글id
  "noticeId": "NOTICE-001", //해당 댓글이 속한 공지사항id
  "writerId": "TESTER-001", //해당 댓글 작성자id
  "writerName": "김테스터", //해당 댓글 작성자 이름
  "writerEmail": "test@gmail.com", //해당 댓글 작성자 이메일
  "content": "수정된 댓글이에요", //댓글 내용
  "createdAt": "2023-11-02T22:45:18.586432", //생성시각
  "updatedAt": "2023-11-06T20:30:40.423211" //수정시각(이 경우 반드시 null 아님)
  "mine": true //현재 로그인한 유저가 작성한 글인지 여부(이 경우 반드시 true 반환)
 }
}  
```


***
### 테스트 결과
![image](https://github.com/Liberty52/auth/assets/96376539/c7efb92e-d46d-4afc-acd8-01144a80f569)


***
### 이슈
none