### PR TITLE
공지사항 댓글 삭제

### DIFF
--- a/src/main/java/com/liberty52/auth/global/exception/external/forbidden/NotYourNoticeCommentException.java
+++ b/src/main/java/com/liberty52/auth/global/exception/external/forbidden/NotYourNoticeCommentException.java
@@ -1,0 +1,7 @@
+package com.liberty52.auth.global.exception.external.forbidden;
+
+public class NotYourNoticeCommentException extends NotYourResourceException{
+    public NotYourNoticeCommentException(String userId){
+        super("NoticeComment", userId);
+    }
+}

--- a/src/main/java/com/liberty52/auth/service/applicationservice/NoticeCommentDeleteService.java
+++ b/src/main/java/com/liberty52/auth/service/applicationservice/NoticeCommentDeleteService.java
@@ -1,0 +1,7 @@
+package com.liberty52.auth.service.applicationservice;
+
+public interface NoticeCommentDeleteService {
+    void deleteNoticeComment(String userId, String noticeId, String commentId);
+
+    void deleteNoticeCommentByAdmin(String role, String noticeId, String commentId);
+}

--- a/src/main/java/com/liberty52/auth/service/controller/NoticeCommentController.java
+++ b/src/main/java/com/liberty52/auth/service/controller/NoticeCommentController.java
@@ -1,6 +1,7 @@
 package com.liberty52.auth.service.controller;
 
 import com.liberty52.auth.service.applicationservice.NoticeCommentCreateService;
+import com.liberty52.auth.service.applicationservice.NoticeCommentDeleteService;
 import com.liberty52.auth.service.applicationservice.NoticeCommentRetrieveService;
 import com.liberty52.auth.service.applicationservice.NoticeCommentUpdateService;
 import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
@@ -22,6 +23,7 @@ public class NoticeCommentController {
     private final NoticeCommentCreateService noticeCommentCreateService;
     private final NoticeCommentRetrieveService noticeCommentRetrieveService;
     private final NoticeCommentUpdateService noticeCommentUpdateService;
+    private final NoticeCommentDeleteService noticeCommentDeleteService;
 
     @Operation(summary = "공지사항 댓글 생성", description = "공지사항에 대한 댓글을 생성합니다.")
     @PostMapping("/notices/{noticeId}/comments")
@@ -43,7 +45,7 @@ public class NoticeCommentController {
         return ResponseEntity.status(HttpStatus.OK).body(responseDtoPage);
     }
 
-    @Operation(summary = "공지사항 댓글 수장", description = "공지사항에 대한 댓글을 수정합니다.")
+    @Operation(summary = "공지사항 댓글 수정", description = "공지사항에 대한 댓글을 수정합니다.")
     @PatchMapping("/notices/{noticeId}/comments/{commentId}")
     public ResponseEntity<NoticeCommentResponseDto> updateNoticeComment(@RequestHeader(HttpHeaders.AUTHORIZATION) String userId,
                                                                         @PathVariable String noticeId,
@@ -53,6 +55,25 @@ public class NoticeCommentController {
         NoticeCommentResponseDto responseDto = new NoticeCommentResponseDto(resultEntity, userId);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
+
+    @Operation(summary = "공지사항 댓글 삭제", description = "공지사항에 대한 댓글을 삭제합니다.")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/notices/{noticeId}/comments/{commentId}")
+    public void deleteNoticeComment(@RequestHeader(HttpHeaders.AUTHORIZATION) String userId,
+                                    @PathVariable String noticeId,
+                                    @PathVariable String commentId){
+        noticeCommentDeleteService.deleteNoticeComment(userId, noticeId, commentId);
+    }
+
+    @Operation(summary = "관리자의 공지사항 댓글 삭제", description = "관리자가 공지사항에 대한 댓글을 삭제합니다.")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("admin/notices/{noticeId}/comments/{commentId}")
+    public void deleteNoticeCommentByAdmin(@RequestHeader("LB-Role") String role,
+                                           @PathVariable String noticeId,
+                                           @PathVariable String commentId){
+        noticeCommentDeleteService.deleteNoticeCommentByAdmin(role, noticeId, commentId);
+    }
+
 
 
 

--- a/src/test/java/com/liberty52/auth/service/applicationservice/NoticeCommentDeleteServiceMockTest.java
+++ b/src/test/java/com/liberty52/auth/service/applicationservice/NoticeCommentDeleteServiceMockTest.java
@@ -1,0 +1,107 @@
+package com.liberty52.auth.service.applicationservice;
+
+import com.liberty52.auth.global.exception.external.forbidden.NotYourNoticeCommentException;
+import com.liberty52.auth.service.applicationservice.impl.NoticeCommentDeleteServiceImpl;
+import com.liberty52.auth.service.entity.Auth;
+import com.liberty52.auth.service.entity.Notice;
+import com.liberty52.auth.service.entity.NoticeComment;
+import com.liberty52.auth.service.entity.Role;
+import com.liberty52.auth.service.repository.AuthRepository;
+import com.liberty52.auth.service.repository.NoticeCommentRepository;
+import com.liberty52.auth.service.repository.NoticeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class NoticeCommentDeleteServiceMockTest {
+    @InjectMocks
+    private NoticeCommentDeleteServiceImpl service;
+
+    @Mock
+    private AuthRepository authRepository;
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @Mock
+    private NoticeCommentRepository noticeCommentRepository;
+
+    @Test
+    public void 공지사항댓글삭제_성공() {
+        //Given
+        String userId = "TESTER-001";
+        String noticeId = "NOTICE-001";
+        String commentId = "COMMENT-001";
+
+        Auth mockWriter = mock(Auth.class);
+        Notice mockNotice = mock(Notice.class);
+        NoticeComment mockComment = mock(NoticeComment.class);
+
+
+        when(authRepository.findById(anyString())).thenReturn(Optional.of(mockWriter));
+        when(noticeRepository.findById(anyString())).thenReturn(Optional.of(mockNotice));
+        when(noticeCommentRepository.findById(anyString())).thenReturn(Optional.of(mockComment));
+        when(mockWriter.getId()).thenReturn(userId);
+        when(mockComment.getWriter()).thenReturn(mockWriter);
+
+        //When
+        service.deleteNoticeComment(userId, noticeId, commentId);
+
+        //Then
+        Mockito.verify(noticeCommentRepository, Mockito.times(1)).delete(mockComment);
+    }
+
+    @Test
+    public void 관리자_공지항댓글삭제_성공() {
+        //Given
+        String role = String.valueOf(Role.ADMIN);
+        String noticeId = "NOTICE-001";
+        String commentId = "COMMENT-001";
+
+        Notice mockNotice = mock(Notice.class);
+        NoticeComment mockComment = mock(NoticeComment.class);
+
+        when(noticeRepository.findById(anyString())).thenReturn(Optional.of(mockNotice));
+        when(noticeCommentRepository.findById(anyString())).thenReturn(Optional.of(mockComment));
+
+        //When
+        service.deleteNoticeCommentByAdmin(role, noticeId, commentId);
+
+        //Then
+        Mockito.verify(noticeCommentRepository, Mockito.times(1)).delete(mockComment);
+    }
+
+    @Test
+    public void 공지사항댓글삭제_실패_나의댓글아님() {
+        //Given
+        String userId = "TESTER-002";
+        String noticeId = "NOTICE-001";
+        String writerId = "TESTER-001";
+        String commentId = "COMMENT-001";
+
+        Auth mockWriter = mock(Auth.class);
+        Notice mockNotice = mock(Notice.class);
+        NoticeComment mockComment = mock(NoticeComment.class);
+
+        when(authRepository.findById(anyString())).thenReturn(Optional.of(mockWriter));
+        when(noticeRepository.findById(anyString())).thenReturn(Optional.of(mockNotice));
+        when(noticeCommentRepository.findById(anyString())).thenReturn(Optional.of(mockComment));
+        when(mockComment.getWriter()).thenReturn(mockWriter);
+        when(mockComment.getWriter().getId()).thenReturn(writerId);
+
+
+        //When&Then
+        assertThrows(NotYourNoticeCommentException.class, () -> service.deleteNoticeComment(userId, noticeId, commentId));
+    }
+}

--- a/src/test/java/com/liberty52/auth/service/applicationservice/NoticeCommentUpdateServiceMockTest.java
+++ b/src/test/java/com/liberty52/auth/service/applicationservice/NoticeCommentUpdateServiceMockTest.java
@@ -44,16 +44,17 @@ public class NoticeCommentUpdateServiceMockTest {
         Notice mockNotice = mock(Notice.class);
         Auth mockWriter = mock(Auth.class);
         NoticeCommentRequestDto mockRequestDto = mock(NoticeCommentRequestDto.class);
-        NoticeComment mockPreviousNoticeComment = NoticeComment.builder()
-                .content("prevContent")
-                .build();
+        NoticeComment mockPreviousNoticeComment = mock(NoticeComment.class);
         NoticeComment mockNewNoticeComment = NoticeComment.builder()
                 .content("newContent")
                 .build();
         when(authRepository.findById(anyString())).thenReturn(Optional.of(mockWriter));
         when(noticeRepository.findById(anyString())).thenReturn(Optional.of(mockNotice));
         when(noticeCommentRepository.findById(anyString())).thenReturn(Optional.of(mockPreviousNoticeComment));
+        when(mockPreviousNoticeComment.getWriter()).thenReturn(mockWriter);
+        when(mockPreviousNoticeComment.getWriter().getId()).thenReturn(testWriterId);
         when(noticeCommentRepository.save(any(NoticeComment.class))).thenReturn(mockNewNoticeComment);
+
 
         //When
         NoticeComment updatedNoticeComment = noticeCommentUpdateService.updateNoticeComment(testWriterId, testNoticeId, testCommentId, mockRequestDto);

--- a/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
+++ b/src/test/java/com/liberty52/auth/service/controller/NoticeCommentControllerTest.java
@@ -2,6 +2,7 @@ package com.liberty52.auth.service.controller;
 
 
 import com.liberty52.auth.service.applicationservice.NoticeCommentCreateService;
+import com.liberty52.auth.service.applicationservice.NoticeCommentDeleteService;
 import com.liberty52.auth.service.applicationservice.NoticeCommentRetrieveService;
 import com.liberty52.auth.service.applicationservice.NoticeCommentUpdateService;
 import com.liberty52.auth.service.controller.dto.NoticeCommentRequestDto;
@@ -42,6 +43,8 @@ public class NoticeCommentControllerTest {
     private NoticeCommentRetrieveService noticeCommentRetrieveService;
     @MockBean
     private NoticeCommentUpdateService noticeCommentUpdateService;
+    @MockBean
+    private NoticeCommentDeleteService noticeCommentDeleteService;
 
     private final String testNoticeId = "NOTICE-001";
     private final String testWriterID = "TESTER-001";


### PR DESCRIPTION
## 스프린트 넘버  : 7
### 백로그 이름 : 공지에서 댓글기능 DELETE


***
### 작업
1. 수정, 삭제 서비스 로직에서 내가 작성한 댓글이 아닐 경우 Forbidden 에러 반환하는 로직 추가
2. 회원의 댓글 삭제 기능
3. 관리자의 댓글 삭제 기능(이번 스프린트의 요구사항은 아니나, 부적절한 댓글에 대한 관리자의 삭제 기능은 필요할 것 같아 우선 넣어놨어요)

**API**

```
<공지사항 댓글 삭제>

DELETE /notices/{noticeId}/comments/{commentId}

<Request>
Header: {
 "Authorization" : ${access_token}
}

<Response>
Status : 204(성공),400(잘못된 데이터로 요청),401(존재하지 않는 유저),403(권한 없음),404(존재하지 않는 공지사항 or 댓글)

```

```
<공지사항 댓글 삭제 (관리자)>

DELETE admin/notices/{noticeId}/comments/{commentId}

<Request>
Header: {
 "LB-Role" : Role
}

<Response>
Status : 204(성공),400(잘못된 데이터로 요청),401(존재하지 않는 유저),403(권한 없음),404(존재하지 않는 공지사항 or 댓글)

```

***
### 테스트 결과
![image](https://github.com/Liberty52/auth/assets/96376539/35c47d1e-fdfd-4991-af7c-316a11c42b9e)


***
### 이슈
none